### PR TITLE
Migrate data ptr

### DIFF
--- a/src/ossl_bn.c
+++ b/src/ossl_bn.c
@@ -54,8 +54,7 @@ static mrb_value mrb_ossl_bn_to_s(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "i", &base);
 
-  value_bn = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "bn"));
-  bn = DATA_PTR(value_bn);
+  bn = DATA_PTR(self);
 
   switch (base) {
   case 2:
@@ -149,6 +148,7 @@ void Init_ossl_bn(mrb_state *mrb)
   eBNError = mrb_define_class_under(mrb, mOSSL, "BNError", eOSSLError);
 
   cBN = mrb_define_class_under(mrb, mOSSL, "BN", mrb->object_class);
+  MRB_SET_INSTANCE_TT(cBN, MRB_TT_DATA);
   mrb_define_method(mrb, cBN, "initialize", ossl_bn_initialize, MRB_ARGS_ARG(1, 1));
 
   mrb_define_method(mrb, cBN, "to_s", mrb_ossl_bn_to_s, MRB_ARGS_REQ(1));

--- a/src/ossl_bn.h
+++ b/src/ossl_bn.h
@@ -2,23 +2,19 @@
 #define _OSSL_BN_H_
 #define NewBN(klass) mrb_obj_value(Data_Wrap_Struct(mrb, klass, &ossl_bn_type, 0))
 
-#define SetBN(obj, bn)                                                                        \
+#define SetBN(obj, bn)                                                                             \
   do {                                                                                             \
     if (!(bn)) {                                                                                   \
       mrb_raise((mrb), E_RUNTIME_ERROR, "BN wasn't initialized!");                                 \
     }                                                                                              \
-    mrb_iv_set(                                                                                    \
-        (mrb), (obj), mrb_intern_lit(mrb, "bn"),                                                   \
-        mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &ossl_bn_type, (void *)bn)));       \
+    DATA_PTR(obj) = bn;                                                                            \
+    DATA_TYPE(obj) = &ossl_bn_type;                                                                \
   } while (0)
 
-#define GetBN(obj, bn)                                                                        \
+#define GetBN(obj, bn)                                                                             \
   do {                                                                                             \
-    mrb_value value_bn;                                                                            \
-    value_bn = mrb_iv_get((mrb), (obj), mrb_intern_lit(mrb, "bn"));                                \
-    bn = DATA_PTR(value_bn);                                                                       \
+    bn = DATA_PTR(obj);                                                                             \
   } while (0)
-
 
 void Init_ossl_bn(mrb_state *mrb);
 mrb_value ossl_bn_new(mrb_state *mrb, const BIGNUM *);

--- a/src/ossl_pkey.c
+++ b/src/ossl_pkey.c
@@ -51,8 +51,7 @@ static mrb_value mrb_ossl_pkey_sign(mrb_state *mrb, mrb_value self)
 
   GetPKey(self, pkey);
 
-  mrb_value value_ctx = mrb_iv_get(mrb, digest_instance, mrb_intern_lit(mrb, "ctx"));
-  ictx = DATA_PTR(value_ctx);
+  ictx = DATA_PTR(digest_instance);
 
   EVP_SignInit(&ctx, ictx->digest);
   EVP_SignUpdate(&ctx, RSTRING_PTR(data), RSTRING_LEN(data));

--- a/src/ossl_pkey.h
+++ b/src/ossl_pkey.h
@@ -9,32 +9,29 @@ mrb_value ossl_pkey_alloc(mrb_state *mrb, mrb_value klass);
 EVP_PKEY *GetPKeyPtr(mrb_state *mrb, mrb_value obj);
 EVP_PKEY *GetPrivPKeyPtr(mrb_state *mrb, VALUE obj);
 
-#define NewPKey(klass)                                                                         \
-  mrb_obj_value(Data_Wrap_Struct(mrb, klass, &ossl_evp_pkey_type, 0))
+#define NewPKey(klass) mrb_obj_value(Data_Wrap_Struct(mrb, klass, &ossl_evp_pkey_type, 0))
 
-#define OSSL_PKEY_SET_PUBLIC(obj)                                                             \
+#define OSSL_PKEY_SET_PUBLIC(obj)                                                                  \
   mrb_iv_set(mrb, (obj), mrb_intern_lit(mrb, "private"), mrb_false_value())
 
-#define SetPKey(obj, pkey)                                                                    \
+#define SetPKey(obj, pkey)                                                                         \
   do {                                                                                             \
     if (!(pkey)) {                                                                                 \
       mrb_raise((mrb), E_RUNTIME_ERROR, "PKEY wasn't initialized!");                               \
     }                                                                                              \
-    mrb_iv_set((mrb), (obj), mrb_intern_lit(mrb, "pkey"),                                          \
-               mrb_obj_value(                                                                      \
-                   Data_Wrap_Struct(mrb, mrb->object_class, &ossl_evp_pkey_type, (void *)pkey)));  \
-    OSSL_PKEY_SET_PUBLIC(obj);                                                                \
+    DATA_PTR(obj) = pkey;                                                                          \
+    DATA_TYPE(obj) = &ossl_evp_pkey_type;                                                          \
+    OSSL_PKEY_SET_PUBLIC(obj);                                                                     \
   } while (0)
 
-#define GetPKey(obj, pkey)                                                                    \
+#define GetPKey(obj, pkey)                                                                         \
   do {                                                                                             \
-    mrb_value value_pkey = mrb_iv_get(mrb, obj, mrb_intern_lit(mrb, "pkey"));                      \
-    pkey = DATA_PTR(value_pkey);                                                                   \
+    pkey = DATA_PTR(obj);                                                                   \
   } while (0)
 
-#define SafeGetPKey(obj, pkey)                                                                \
+#define SafeGetPKey(obj, pkey)                                                                     \
   do {                                                                                             \
-    OSSL_Check_Kind(mrb, (obj), cPKey);                                                          \
-    GetPKey((obj), (pkey));                                                                \
+    OSSL_Check_Kind(mrb, (obj), cPKey);                                                            \
+    GetPKey((obj), (pkey));                                                                        \
   } while (0)
 #endif /* _OSSL_PKEY_H_ */

--- a/src/ossl_pkey_rsa.c
+++ b/src/ossl_pkey_rsa.c
@@ -110,7 +110,6 @@ static mrb_value mrb_ossl_pkey_rsa_init(mrb_state *mrb, mrb_value self)
     if (!rsa) {
       mrb_raise(mrb, eRSAError, "Neither PUB key nor PRIV key");
     }
-
   }
 
   if (!EVP_PKEY_assign_RSA(pkey, rsa)) {
@@ -188,7 +187,7 @@ mrb_value mrb_ossl_rsa_is_private(mrb_state *mrb, mrb_value self)
   return (RSA_PRIVATE(self, pkey->pkey.rsa)) ? mrb_bool_value(true) : mrb_bool_value(false);
 }
 
-  OSSL_PKEY_BN(rsa, n)
+OSSL_PKEY_BN(rsa, n)
 OSSL_PKEY_BN(rsa, e)
 
 static VALUE ossl_rsa_export(mrb_state *mrb, VALUE self)
@@ -211,7 +210,7 @@ static VALUE ossl_rsa_export(mrb_state *mrb, VALUE self)
   }
   if (RSA_HAS_PRIVATE(pkey->pkey.rsa)) {
     if (!PEM_write_bio_RSAPrivateKey(out, pkey->pkey.rsa, ciph, NULL, 0, ossl_pem_passwd_cb,
-          passwd)) {
+                                     passwd)) {
       BIO_free(out);
       mrb_raise(mrb, eRSAError, NULL);
     }
@@ -230,6 +229,8 @@ void Init_ossl_rsa(mrb_state *mrb)
 {
 
   cRSA = mrb_define_class_under(mrb, mPKey, "RSA", cPKey);
+  MRB_SET_INSTANCE_TT(cRSA, MRB_TT_DATA);
+
   eRSAError = mrb_define_class_under(mrb, mPKey, "RSAError", ePKeyError);
 
   mrb_define_method(mrb, cRSA, "initialize", mrb_ossl_pkey_rsa_init, MRB_ARGS_ARG(1, 1));

--- a/src/ossl_pkey_rsa.h
+++ b/src/ossl_pkey_rsa.h
@@ -23,8 +23,7 @@ mrb_value ossl_rsa_new(mrb_state *mrb, EVP_PKEY *pkey);
     mrb_value value_pkey;                                                                          \
     BIGNUM *bn;                                                                                    \
                                                                                                    \
-    value_pkey = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "pkey"));                               \
-    pkey = DATA_PTR(value_pkey);                                                                   \
+    pkey = DATA_PTR(self);                                                                   \
     bn = pkey->pkey.keytype->name;                                                                 \
     if (bn == NULL)                                                                                \
       return mrb_nil_value();                                                                      \

--- a/src/ossl_x509attr.c
+++ b/src/ossl_x509attr.c
@@ -124,6 +124,7 @@ void Init_ossl_x509attr(mrb_state *mrb)
   eX509AttrError = mrb_define_class_under(mrb, mX509, "AttributeError", eOSSLError);
 
   cX509Attr = mrb_define_class_under(mrb, mX509, "Attribute", mrb->object_class);
+  MRB_SET_INSTANCE_TT(cX509Attr, MRB_TT_DATA);
   mrb_define_method(mrb, cX509Attr, "initialize", ossl_x509attr_initialize, MRB_ARGS_ARG(1, 1));
   mrb_define_method(mrb, cX509Attr, "oid=", ossl_x509attr_set_oid, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, cX509Attr, "oid", ossl_x509attr_get_oid, MRB_ARGS_NONE());

--- a/src/ossl_x509attr.h
+++ b/src/ossl_x509attr.h
@@ -2,13 +2,11 @@
     if (!(attr)) { \
       mrb_raise((mrb), E_RUNTIME_ERROR, "ATTR wasn't initialized!");                               \
     } \
-    mrb_iv_set((mrb), (obj), mrb_intern_lit(mrb, "x509attr"),                                          \
-               mrb_obj_value(                                                                      \
-                   Data_Wrap_Struct(mrb, mrb->object_class, &ossl_x509attr_type, (void *)attr)));  \
+    DATA_PTR(obj) = attr; \
+    DATA_TYPE(obj) = &ossl_x509attr_type; \
 } while (0)
 #define GetX509Attr(obj, attr) do { \
-    mrb_value value_attr = mrb_iv_get(mrb, obj, mrb_intern_lit(mrb, "x509attr"));                      \
-    attr = DATA_PTR(value_attr);                                                                   \
+    attr = DATA_PTR(obj);                                                                   \
     if (!(attr)) { \
       mrb_raise((mrb), E_RUNTIME_ERROR, "ATTR wasn't initialized!");                               \
     } \

--- a/src/ossl_x509cert.c
+++ b/src/ossl_x509cert.c
@@ -3,17 +3,15 @@ struct RClass *cX509Cert;
 struct RClass *eX509CertError;
 #define GetX509(obj, x509)                                                                    \
   do {                                                                                             \
-    mrb_value value_x509 = mrb_iv_get(mrb, obj, mrb_intern_lit(mrb, "x509"));                      \
-    x509 = DATA_PTR(value_x509);                                                                   \
+    x509 = DATA_PTR(obj);                                                                   \
   } while (0)
 #define SetX509(obj, x509)                                                                    \
   do {                                                                                             \
     if (!(x509)) {                                                                                 \
       mrb_raise((mrb), E_RUNTIME_ERROR, " wasn't initialized!");                                   \
     }                                                                                              \
-    mrb_iv_set(                                                                                    \
-        (mrb), (obj), mrb_intern_lit(mrb, "x509"),                                                 \
-        mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &ossl_x509_type, (void *)x509)));   \
+    DATA_PTR(obj) = x509; \
+    DATA_TYPE(obj) = &ossl_x509_type; \
   } while (0)
 #define SafeGetX509(obj, x509)                                                                \
   do {                                                                                             \
@@ -90,6 +88,7 @@ void Init_ossl_x509cert(mrb_state *mrb)
 {
   eX509CertError = mrb_define_class_under(mrb, mX509, "CertificateError", eOSSLError);
   cX509Cert = mrb_define_class_under(mrb, mX509, "Certificate", mrb->object_class);
+  MRB_SET_INSTANCE_TT(cX509Cert, MRB_TT_DATA);
   mrb_define_method(mrb, cX509Cert, "initialize", ossl_x509_initialize, MRB_ARGS_OPT(1));
   mrb_define_method(mrb, cX509Cert, "to_pem", ossl_x509_to_pem, 0);
 }

--- a/src/ossl_x509crl.c
+++ b/src/ossl_x509crl.c
@@ -1,8 +1,7 @@
 #include "ossl.h"
 #define GetX509CRL(obj, crl)                                                                  \
   do {                                                                                             \
-    mrb_value value_crl = mrb_iv_get(mrb, obj, mrb_intern_lit(mrb, "x509crl"));                    \
-    crl = DATA_PTR(value_crl);                                                                     \
+    crl = DATA_PTR(obj);                                                                     \
   } while (0)
 
 #define SafeGetX509CRL(obj, crl)                                                              \

--- a/src/ossl_x509ext.c
+++ b/src/ossl_x509ext.c
@@ -3,35 +3,31 @@ struct RClass *cX509Ext;
 struct RClass *cX509ExtFactory;
 struct RClass *eX509ExtError;
 
-#define MakeX509ExtFactory(obj, ctx)                                                          \
+#define MakeX509ExtFactory(obj, ctx)                                                               \
   do {                                                                                             \
     if (!((ctx) = OPENSSL_malloc(sizeof(X509V3_CTX))))                                             \
       mrb_raise(mrb, E_RUNTIME_ERROR, "CTX wasn't allocated!");                                    \
     X509V3_set_ctx((ctx), NULL, NULL, NULL, NULL, 0);                                              \
-    mrb_iv_set((mrb), (obj), mrb_intern_lit(mrb, "x509extfactory"),                                \
-               mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &ossl_x509extfactory_type,   \
-                                              (void *)ctx)));                                      \
+    DATA_PTR(obj) = ctx;                                                                           \
+    DATA_TYPE(obj) = &ossl_x509extfactory_type;                                                    \
   } while (0)
-#define GetX509ExtFactory(obj, ctx)                                                           \
+#define GetX509ExtFactory(obj, ctx)                                                                \
   do {                                                                                             \
-    mrb_value value_ctx = mrb_iv_get(mrb, obj, mrb_intern_lit(mrb, "x509extfactory"));             \
-    ctx = DATA_PTR(value_ctx);                                                                     \
+    ctx = DATA_PTR(obj);                                                                           \
   } while (0)
 
-#define SetX509Ext(obj, ext)                                                                  \
+#define SetX509Ext(obj, ext)                                                                       \
   do {                                                                                             \
     if (!(ext)) {                                                                                  \
       mrb_raise(mrb, E_RUNTIME_ERROR, "EXT wasn't initialized!");                                  \
     }                                                                                              \
-    mrb_iv_set(                                                                                    \
-        (mrb), (obj), mrb_intern_lit(mrb, "x509ext"),                                              \
-        mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &ossl_x509ext_type, (void *)ext))); \
+    DATA_PTR(obj) = ext;                                                                           \
+    DATA_TYPE(obj) = &ossl_x509ext_type;                                                           \
   } while (0)
 
-#define GetX509Ext(obj, ctx)                                                                  \
+#define GetX509Ext(obj, ctx)                                                                       \
   do {                                                                                             \
-    mrb_value value_ctx = mrb_iv_get(mrb, obj, mrb_intern_lit(mrb, "x509ext"));                    \
-    ctx = DATA_PTR(value_ctx);                                                                     \
+    ctx = DATA_PTR(obj);                                                                           \
   } while (0)
 
 static void ossl_x509extfactory_free(mrb_state *mrb, void *ctx)
@@ -183,11 +179,14 @@ void Init_ossl_x509ext(mrb_state *mrb)
 {
   eX509ExtError = mrb_define_class_under(mrb, mX509, "ExtensionError", eOSSLError);
   cX509ExtFactory = mrb_define_class_under(mrb, mX509, "ExtensionFactory", mrb->object_class);
+  MRB_SET_INSTANCE_TT(cX509ExtFactory, MRB_TT_DATA);
   mrb_define_method(mrb, cX509ExtFactory, "initialize", ossl_x509extfactory_initialize,
                     MRB_ARGS_OPT(4));
-  mrb_define_method(mrb, cX509ExtFactory, "create_ext", ossl_x509extfactory_create_ext, MRB_ARGS_ARG(2, 1));
+  mrb_define_method(mrb, cX509ExtFactory, "create_ext", ossl_x509extfactory_create_ext,
+                    MRB_ARGS_ARG(2, 1));
 
   cX509Ext = mrb_define_class_under(mrb, mX509, "Extension", mrb->object_class);
+  MRB_SET_INSTANCE_TT(cX509Ext, MRB_TT_DATA);
   mrb_define_method(mrb, cX509Ext, "initialize", ossl_x509ext_init, MRB_ARGS_NONE());
   mrb_define_method(mrb, cX509Ext, "to_der", ossl_x509ext_to_der, MRB_ARGS_NONE());
 }

--- a/src/ossl_x509name.c
+++ b/src/ossl_x509name.c
@@ -96,6 +96,7 @@ void Init_ossl_x509name(mrb_state *mrb)
 {
   eX509NameError = mrb_define_class_under(mrb, mX509, "NameError", eOSSLError);
   cX509Name = mrb_define_class_under(mrb, mX509, "Name", mrb->object_class);
+  MRB_SET_INSTANCE_TT(cX509Name, MRB_TT_DATA);
   mrb_define_method(mrb, cX509Name, "initialize", ossl_x509name_initialize, MRB_ARGS_OPT(2));
   mrb_define_method(mrb, cX509Name, "add_entry", ossl_x509name_add_entry, MRB_ARGS_ARG(2, 1));
 }

--- a/src/ossl_x509name.h
+++ b/src/ossl_x509name.h
@@ -3,8 +3,7 @@ extern struct RClass *cX509Name;
 extern struct RClass *eX509NameError;
 #define GetX509Name(obj, name)                                                                \
   do {                                                                                             \
-    mrb_value value_name = mrb_iv_get(mrb, obj, mrb_intern_lit(mrb, "x509name"));                  \
-    name = DATA_PTR(value_name);                                                                   \
+    name = DATA_PTR(obj);                                                                   \
   } while (0)
 
 #define SetX509Name(obj, name)                                                                \
@@ -12,9 +11,8 @@ extern struct RClass *eX509NameError;
     if (!(name)) {                                                                                 \
       mrb_raise((mrb), E_RUNTIME_ERROR, "Name wasn't initialized!");                               \
     }                                                                                              \
-    mrb_iv_set((mrb), (obj), mrb_intern_lit(mrb, "x509name"),                                      \
-               mrb_obj_value(                                                                      \
-                   Data_Wrap_Struct(mrb, mrb->object_class, &ossl_x509name_type, (void *)name)));  \
+    DATA_PTR(obj) = name; \
+    DATA_TYPE(obj) = &ossl_x509name_type; \
   } while (0)
 #define SafeGetX509Name(obj, name)                                                            \
   do {                                                                                             \

--- a/src/ossl_x509req.c
+++ b/src/ossl_x509req.c
@@ -7,15 +7,12 @@ struct RClass *cX509Req;
     if (!(req)) {                                                                                  \
       mrb_raise((mrb), E_RUNTIME_ERROR, "Req wasn't initialized!");                                \
     }                                                                                              \
-    mrb_iv_set((mrb), (obj), mrb_intern_lit(mrb, "x509req"),                                       \
-               mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &ossl_x509_request_type,     \
-                                              (void *)req)));                                      \
+    DATA_PTR(obj) = req; \
+    DATA_TYPE(obj) = &ossl_x509_request_type; \
   } while (0)
 #define GetX509Req(obj, req)                                                                  \
   do {                                                                                             \
-    mrb_value value_req;                                                                           \
-    value_req = mrb_iv_get((mrb), (obj), mrb_intern_lit(mrb, "x509req"));                          \
-    req = DATA_PTR(value_req);                                                                     \
+    req = DATA_PTR(obj);                          \
   } while (0)
 
 #define SafeGetX509Req(obj, req)                                                              \
@@ -196,6 +193,7 @@ void Init_ossl_x509req(mrb_state *mrb)
   eX509ReqError = mrb_define_class_under(mrb, mX509, "RequestError", eOSSLError);
 
   cX509Req = mrb_define_class_under(mrb, mX509, "Request", mrb->object_class);
+  MRB_SET_INSTANCE_TT(cX509Req, MRB_TT_DATA);
   mrb_define_method(mrb, cX509Req, "initialize", ossl_x509req_initialize, MRB_ARGS_OPT(1));
   mrb_define_method(mrb, cX509Req, "public_key=", ossl_x509req_set_public_key, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, cX509Req, "subject=", ossl_x509req_set_subject, MRB_ARGS_REQ(1));


### PR DESCRIPTION
mrubyの構造体のパックがインスタンス変数によって実現されていたので、DATA_PTRを利用してインスタンスのdataに格納するようにしました。