### PR TITLE
Include only when the version is 3.2 or higher

### DIFF
--- a/src/ossl.h
+++ b/src/ossl.h
@@ -9,7 +9,7 @@
 #include "mruby/compile.h"
 #include "mruby/data.h"
 #include "mruby/hash.h"
-#if MRUBY_RELEASE_MAJOR >= 3 && MRUBY_RELEASE_MINOR >= 2
+#if MRUBY_RELEASE_MAJOR > 3 || (MRUBY_RELEASE_MAJOR == 3 && MRUBY_RELEASE_MINOR >= 2)
 #include "mruby/internal.h"
 #endif
 #include "mruby/object.h"

--- a/src/ossl.h
+++ b/src/ossl.h
@@ -9,7 +9,9 @@
 #include "mruby/compile.h"
 #include "mruby/data.h"
 #include "mruby/hash.h"
+#if MRUBY_RELEASE_MAJOR >= 3 && MRUBY_RELEASE_MINOR >= 2
 #include "mruby/internal.h"
+#endif
 #include "mruby/object.h"
 #include "mruby/string.h"
 #include "mruby/variable.h"


### PR DESCRIPTION
Fix build errors when using less than mruby 3.2